### PR TITLE
Add Senior Backend Engineer CV template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # nguyennm96.github.io
+
+This repository hosts the personal site.
+
+- `cv.html`: mẫu CV cho vị trí **Senior Backend Engineer** với phong cách hiện đại. Tuỳ chỉnh các trường để phù hợp với thông tin cá nhân.
+

--- a/cv.html
+++ b/cv.html
@@ -1,0 +1,133 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="UTF-8" />
+  <title>Senior Backend Engineer CV</title>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;700&display=swap" rel="stylesheet" />
+  <style>
+    body {
+      font-family: 'Inter', sans-serif;
+      margin: 0;
+      background: #f5f5f5;
+      color: #333;
+    }
+    .container {
+      display: grid;
+      grid-template-columns: 280px 1fr;
+      min-height: 100vh;
+    }
+    .sidebar {
+      background: #2e3a4e;
+      color: #fff;
+      padding: 2rem;
+    }
+    .sidebar a {
+      color: #f39c12;
+      text-decoration: none;
+    }
+    .sidebar h1 {
+      color: #f39c12;
+      font-size: 2rem;
+      margin: 0 0 1rem 0;
+    }
+    .sidebar h2 {
+      color: #f39c12;
+      border-bottom: 2px solid #f39c12;
+      padding-bottom: 0.5rem;
+      margin-top: 2rem;
+    }
+    .sidebar ul {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+    }
+    .sidebar li {
+      margin-bottom: 0.5rem;
+    }
+    .content {
+      padding: 2rem 3rem;
+    }
+    .content h2 {
+      color: #f39c12;
+      margin-top: 0;
+    }
+    article h3 {
+      margin-bottom: 0.2rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <aside class="sidebar">
+      <h1>Họ Tên</h1>
+      <p>Senior Backend Engineer</p>
+      <div class="contact">
+        <h2>Liên hệ</h2>
+        <ul>
+          <li>📍 Thành phố, Quốc gia</li>
+          <li>📞 0123-456-789</li>
+          <li>✉️ email@example.com</li>
+          <li><a href="#">LinkedIn</a> | <a href="#">GitHub</a></li>
+          <li><!-- QR Code placeholder --></li>
+        </ul>
+      </div>
+      <div class="skills">
+        <h2>Kỹ năng</h2>
+        <ul>
+          <li><strong>Ngôn ngữ:</strong> Go, Java, Python, Node.js</li>
+          <li><strong>CSDL:</strong> PostgreSQL, MongoDB, Redis</li>
+          <li><strong>DevOps:</strong> Docker, Kubernetes, AWS, Terraform</li>
+          <li><strong>Khác:</strong> Kafka, CI/CD, Clean Architecture</li>
+        </ul>
+      </div>
+      <div class="interests">
+        <h2>Sở thích</h2>
+        <p>Chạy bộ, chơi guitar, hackathons và chia sẻ kiến thức kỹ thuật.</p>
+      </div>
+    </aside>
+    <main class="content">
+      <section class="summary">
+        <h2>Tóm tắt</h2>
+        <p>Kỹ sư Backend với hơn X năm kinh nghiệm xây dựng hệ thống phân tán, API hiệu năng cao và kiến trúc microservices. Đam mê tối ưu hoá hệ thống, cải thiện độ tin cậy và thiết kế giải pháp tích hợp.</p>
+      </section>
+      <section class="experience">
+        <h2>Kinh nghiệm làm việc</h2>
+        <article>
+          <h3>Senior Backend Engineer – Công ty A</h3>
+          <p><em>MM/YYYY – Hiện tại, Địa điểm</em></p>
+          <ul>
+            <li>Thiết kế và triển khai kiến trúc microservices, giảm X% thời gian phản hồi hệ thống.</li>
+            <li>Dẫn dắt đội xây dựng pipeline CI/CD tự động, rút ngắn thời gian triển khai từ Y giờ xuống Z phút.</li>
+            <li>Thực hiện monitoring & alerting (Prometheus, Grafana), cải thiện độ tin cậy lên 99.9%.</li>
+          </ul>
+        </article>
+        <article>
+          <h3>Backend Engineer – Công ty B</h3>
+          <p><em>MM/YYYY – MM/YYYY, Địa điểm</em></p>
+          <ul>
+            <li>Xây dựng hệ thống xử lý dữ liệu theo batch và real-time, đáp ứng hàng triệu request/ngày.</li>
+            <li>Tối ưu truy vấn DB và cache layer, giảm 40% chi phí hạ tầng.</li>
+            <li>Phối hợp chặt chẽ với Frontend và Data teams để cải thiện trải nghiệm người dùng.</li>
+          </ul>
+        </article>
+      </section>
+      <section class="projects">
+        <h2>Dự án tiêu biểu</h2>
+        <ul>
+          <li><strong>Realtime Analytics Service</strong> – Hệ thống phân tích thời gian thực, xử lý 10k events/s.</li>
+          <li><strong>DevOps Automation Toolkit</strong> – Bộ script & template Terraform/Ansible giúp tự động hoá triển khai.</li>
+          <li><strong>Open-Source Contributions</strong> – Đóng góp code cho [Tên project], nhận được X stars trên GitHub.</li>
+        </ul>
+      </section>
+      <section class="education">
+        <h2>Học vấn & Chứng chỉ</h2>
+        <p><strong>[Tên trường đại học]</strong> – Cử nhân / Thạc sĩ Khoa học Máy tính (MM/YYYY – MM/YYYY)</p>
+        <ul>
+          <li>AWS Certified Solutions Architect</li>
+          <li>CKAD – Certified Kubernetes Application Developer</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add styled `cv.html` for Senior Backend Engineer CV
- document CV template in README

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6898b5158afc832db90af078361914b5